### PR TITLE
[CLIENT-7656] Add audio recording feature to `InputTest` and improve unit tests.

### DIFF
--- a/lib/polyfills/Blob.ts
+++ b/lib/polyfills/Blob.ts
@@ -1,0 +1,19 @@
+import { UnsupportedError } from '../errors';
+
+/**
+ * @internalapi
+ * Common error that can be thrown when the polyfill is unable to work.
+ */
+export const BlobUnsupportedError: UnsupportedError =
+  new UnsupportedError(
+    'Blob is not supported by this browser.',
+  );
+
+/**
+ * @interalapi
+ * Simple polyfill for `Blob`.
+ */
+export const BlobPolyfill: typeof window.Blob | undefined =
+  typeof window !== 'undefined'
+    ? window.Blob
+    : undefined;

--- a/lib/polyfills/MediaRecorder.ts
+++ b/lib/polyfills/MediaRecorder.ts
@@ -1,0 +1,19 @@
+import { UnsupportedError } from '../errors';
+
+/**
+ * @internalapi
+ * Common error that can be thrown when the polyfill is unable to work.
+ */
+export const MediaRecorderUnsupportedError: UnsupportedError =
+  new UnsupportedError(
+    'MediaRecorder is not supported by this browser.',
+  );
+
+/**
+ * @interalapi
+ * Simple polyfill for `MediaRecorder`.
+ */
+export const MediaRecorderPolyfill: typeof window.MediaRecorder | undefined =
+  typeof window !== 'undefined'
+    ? window.MediaRecorder
+    : undefined;

--- a/lib/polyfills/createObjectURL.ts
+++ b/lib/polyfills/createObjectURL.ts
@@ -1,0 +1,19 @@
+import { UnsupportedError } from '../errors';
+
+/**
+ * @internalapi
+ * Common error that can be thrown when the polyfill is unable to work.
+ */
+export const createObjectURLUnsupportedError: UnsupportedError =
+  new UnsupportedError(
+    'createObjectURL is not supported by this browser.',
+  );
+
+/**
+ * @interalapi
+ * Simple polyfill for `createObjectURL`.
+ */
+export const createObjectURLPolyfill: typeof window.URL.createObjectURL | undefined =
+  typeof window !== 'undefined' && typeof window.URL !== 'undefined'
+    ? window.URL.createObjectURL
+    : undefined;

--- a/lib/polyfills/index.ts
+++ b/lib/polyfills/index.ts
@@ -7,6 +7,14 @@ export {
   AudioContextUnsupportedError,
 } from './AudioContext';
 export {
+  BlobPolyfill as Blob,
+  BlobUnsupportedError,
+} from './Blob';
+export {
+  createObjectURLPolyfill as createObjectURL,
+  createObjectURLUnsupportedError,
+} from './createObjectURL';
+export {
   enumerateDevicesPolyfill as enumerateDevices,
   enumerateDevicesUnsupportedMessage,
   EnumerateDevicesUnsupportedError,
@@ -16,3 +24,7 @@ export {
   getUserMediaPolyfill as getUserMedia,
   GetUserMediaUnsupportedError,
 } from './getUserMedia';
+export {
+  MediaRecorderPolyfill as MediaRecorder,
+  MediaRecorderUnsupportedError,
+} from './MediaRecorder';

--- a/lib/utils/optionValidation.ts
+++ b/lib/utils/optionValidation.ts
@@ -131,7 +131,7 @@ export function createAudioDeviceValidator(
  * otherwise `undefined`.
  */
 export function validateDeviceId(option: any): Validity {
-  if (option && typeof option !== 'string') {
+  if (!['undefined', 'string'].includes(typeof option)) {
     return 'If "deviceId" is defined, it must be a "string".';
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
   "private": true,
   "dependencies": {
     "@types/events": "3.0.0",
-    "@types/node": "12.12.11",
+    "@types/node": "14.0.13",
     "events": "3.0.0"
   },
   "devDependencies": {
+    "@types/dom-mediacapture-record": "1.0.6",
     "@types/mocha": "5.2.7",
-    "@types/sinon": "7.5.1",
+    "@types/sinon": "9.0.4",
     "browserify": "16.5.0",
     "coverage": "0.4.1",
     "is-docker": "2.0.0",
@@ -55,7 +56,7 @@
     "npm-run-all": "4.1.5",
     "nyc": "15.0.0",
     "release-tool": "git://github.com/twilio/release-tool#8860ca9",
-    "sinon": "7.5.0",
+    "sinon": "9.0.2",
     "travis-multirunner": "4.6.0",
     "ts-node": "8.5.2",
     "tsify": "4.0.1",

--- a/tests/mocks/MockBlob.ts
+++ b/tests/mocks/MockBlob.ts
@@ -1,0 +1,17 @@
+export function mockBlobFactory(opts?: Partial<{
+  size: number,
+  type: string,
+}>) {
+  const {
+    size,
+    type,
+  } = {
+    size: 0,
+    type: 'foobar',
+    ...opts,
+  };
+  return class {
+    size = size;
+    type = type;
+  };
+}

--- a/tests/mocks/MockMediaRecorder.ts
+++ b/tests/mocks/MockMediaRecorder.ts
@@ -1,0 +1,45 @@
+import { EventEmitter } from 'events';
+import { mockBlobFactory } from './MockBlob';
+
+export const defaultBlobEvent = {
+  data: new (mockBlobFactory())(),
+  type: 'dataavailable',
+};
+
+export function mockMediaRecorderFactory(opts: {
+  blobEvent?: any,
+  throw?: { construction?: any, start?: any, stop?: any },
+} = {}) {
+  const options = { blobEvent: defaultBlobEvent, ...opts };
+  return class MockMediaRecorder extends EventEmitter {
+    addEventListener = this.addListener;
+    interval: NodeJS.Timeout | null = null;
+    removeEventListener = this.removeListener;
+    stream: MediaStream;
+    constructor(stream: MediaStream) {
+      super();
+      if (options.throw?.construction) {
+        throw options.throw.construction;
+      }
+      this.stream = stream;
+    }
+    start(intervalMs: number) {
+      if (options.throw?.start) {
+        throw options.throw.start;
+      }
+      this.interval = setInterval(
+        () => this.emit('dataavailable', options.blobEvent),
+        intervalMs,
+      );
+    }
+    stop() {
+      if (options.throw?.stop) {
+        throw options.throw.stop;
+      }
+      if (this.interval) {
+        clearInterval(this.interval);
+      }
+      this.emit('stop');
+    }
+  };
+}

--- a/tests/mocks/mockEnumerateDevices.ts
+++ b/tests/mocks/mockEnumerateDevices.ts
@@ -1,12 +1,12 @@
 export function mockEnumerateDevicesFactory(options: {
   devices: MediaDeviceInfo[],
-  doThrow?: any;
+  throw?: any;
 } = {
   devices: [],
 }) {
   return async (): Promise<MediaDeviceInfo[]> => {
-    if (options.doThrow) {
-      throw options.doThrow;
+    if (options.throw) {
+      throw options.throw;
     }
     return options.devices;
   };

--- a/tests/mocks/mockGetUserMedia.ts
+++ b/tests/mocks/mockGetUserMedia.ts
@@ -1,11 +1,17 @@
+import * as sinon from 'sinon';
 import { MockMediaStream } from './MockMediaStream';
 
-export function mockGetUserMediaFactory(options: MockGetUserMediaOptions = {}) {
-  return async function mockGetUserMedia() {
-    return options.mediaStream || new MockMediaStream();
+export function mockGetUserMediaFactory(opts: MockGetUserMediaOptions = {}) {
+  const options = {
+    mediaStream: new MockMediaStream(),
+    ...opts,
   };
+  return options.throw
+    ? sinon.stub().throws(options.throw)
+    : sinon.stub().returns(Promise.resolve(options.mediaStream));
 }
 
 export interface MockGetUserMediaOptions {
   mediaStream?: MockMediaStream;
+  throw?: any;
 }


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-0000](https://issues.corp.twilio.com/browse/CLIENT-0000)

### Description

This PR adds the ability to record audio during an `InputTest` and returns an object URL for an audio blob within the report. It also reworks unit tests for `InputTest`.

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
