### PR TITLE
CLIENT-7793 | Fail the test if setSinkId is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.0.0-preview4 (In progress)
+=============================
+
+Bug Fixes
+---------
+
+* Fixed an issue where output device test doesn't fail after providing a deviceId on browsers that doesn't support [setSinkId](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId);
+
 1.0.0-preview3 (June 17, 2020)
 ==============================
 

--- a/lib/OutputTest.ts
+++ b/lib/OutputTest.ts
@@ -390,11 +390,10 @@ export class OutputTest extends EventEmitter {
         this._audio.push(destinationAudio);
       } else {
         if (this._options.deviceId && !setSinkIdSupported) {
-          // Non-fatal error
-          this._onError(new UnsupportedError(
+          throw new UnsupportedError(
             'A `deviceId` was passed to the `OutputTest` but `setSinkId` is ' +
             'not supported in this browser.',
-          ));
+          );
         }
         analyser.connect(this._audioContext.destination);
       }

--- a/tests/unit/OutputTest.ts
+++ b/tests/unit/OutputTest.ts
@@ -366,17 +366,26 @@ describe('testOutputDevice', function() {
   });
 
   it('should not allow `deviceId` if `setSinkId` is unsupported', async function() {
-    await assert.rejects(() => new Promise((_, reject) => {
-      const test = testOutputDevice({
-        audioContextFactory: mockAudioContextFactory() as any,
-        audioElementFactory: mockAudioElementFactory({ supportSetSinkId: false }) as any,
-        deviceId: 'foobar',
-        enumerateDevices: mockEnumerateDevicesFactory({
-          devices: [{ deviceId: 'foobar', kind: 'audiooutput' } as any],
-        }),
-      });
-      test.on(OutputTest.Events.Error, err => reject(err));
-    }));
+    const test = testOutputDevice({
+      audioContextFactory: mockAudioContextFactory() as any,
+      audioElementFactory: mockAudioElementFactory({ supportSetSinkId: false }) as any,
+      deviceId: 'foobar',
+      enumerateDevices: mockEnumerateDevicesFactory({
+        devices: [{ deviceId: 'foobar', kind: 'audiooutput' } as any],
+      }),
+    });
+
+    const results = await Promise.all([
+      new Promise(resolve => test.on(OutputTest.Events.Error, resolve)),
+      new Promise(resolve => test.on(OutputTest.Events.End, resolve)),
+    ]);
+
+    const error = results[0] as DiagnosticError;
+    const report = results[1] as OutputTest.Report;
+
+    assert(error);
+    assert(report);
+    assert(!report.didPass);
   });
 
   it('should throw during setup when `enumerateDevices` is not supported', async function() {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7793](https://issues.corp.twilio.com/browse/CLIENT-7793)

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
