### PR TITLE
Add RTT logging capability

### DIFF
--- a/tests/mocks/MockRTCPeerConnection.ts
+++ b/tests/mocks/MockRTCPeerConnection.ts
@@ -24,6 +24,9 @@ export const mockRTCPeerConnectionFactory = (
         throw new Error();
       }
     }
+    getStats: (...args: any[]) => Promise<any> = () => {
+      return new Promise((...args: any[]) => {});
+    }
     ondatachannel: (...args: any[]) => void = () => {};
     onicecandidate: (...args: any[]) => void = () => {};
     async setLocalDescription() {}

--- a/tests/unit/BitrateTest.ts
+++ b/tests/unit/BitrateTest.ts
@@ -37,6 +37,7 @@ describe('BitrateTest', () => {
       this.createOffer = sinon.stub().returns(Promise.resolve());
       this.addIceCandidate = sinon.stub().returns({catch: sinon.stub()});
       this.createDataChannel = sinon.stub().returns(rtcDataChannel);
+      this.getStats = sinon.stub().returns(Promise.resolve());
 
       // The tests always uses 2 PeerConnections
       // The first one is always the receiver
@@ -399,6 +400,7 @@ describe('BitrateTest', () => {
           bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
             assert.deepStrictEqual(report, {
               averageBitrate: values.reduce((total: number, value: number) => total += value, 0) / values.length,
+              averageRtt: 0,
               didPass: false,
               errors: [],
               iceCandidateStats: [],


### PR DESCRIPTION
Since this library is provided to determine connection quality, it makes sense to include all available / useful parameters. Sadly, the DataChannel specification doesn't include jitter or packet loss in the `getStats` API, but `totalRoundTripTime` is available and is useful.  This PR surfaces that data in the resulting report.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### Description

This PR logs `totalRoundTripTime` values for the duration of the test, then totals those values and finds the average. The result is returned in the parameter `averageRTT` in the resulting report.

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [X] Verified locally with `npm test`
* [X] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
