### PR TITLE
CLIENT-7499 | Add timeout error to bitrate test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 Changes
 -------
 
+* Added a new DiagnosticError, `TimeoutError`, which is emitted when a BitrateTest times out (15 seconds).
+
 * Added ICE Candidate related statistics in the [BitrateTest.Report](https://twilio.github.io/rtc-diagnostics/interfaces/bitratetest.report.html) object.
 
   **Example Usage**

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -34,6 +34,12 @@ export const INCOMING_SOUND_URL: string =
 
 /**
  * @private
+ * The number of milliseconds to wait to receive data in bitrate test before timing out.
+ */
+export const BITRATE_TEST_TIMEOUT_MS: number = 15000;
+
+/**
+ * @private
  * Test names.
  */
 export enum TestNames {


### PR DESCRIPTION
## Pull Request Details

### JIRA link(s):

- [CLIENT-7499](https://issues.corp.twilio.com/browse/CLIENT-7499)

### Description

This PR adds a new error, TimeoutError, which is emitted from BitrateTest.on('error') when a timeout occurs (15 seconds after BitrateTests starts, without receiving any data).

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
