### PR TITLE
[CLIENT-7906] Remove `didPass` from audio device test reports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.0.0 (In Progress)
+===================
+
+Changes
+-------
+
+The audio device tests `InputTest` and `OutputTest` no longer perform any analysis on volume data and their reports do not include a `didPass` member in their reports. The member function `.stop()` for both of these classes also no longer accept a `pass` parameter due to this change.
+
 1.0.0-beta1 (July 29, 2020)
 ============================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-1.0.0 (In Progress)
-===================
+1.0.0-beta2 (In Progress)
+=========================
 
 Changes
 -------
 
-The audio device tests `InputTest` and `OutputTest` no longer perform any analysis on volume data and their reports do not include a `didPass` member in their reports. The member function `.stop()` for both of these classes also no longer accept a `pass` parameter due to this change.
+The audio device tests `InputTest` and `OutputTest` no longer perform any analysis on volume data. With this change, `InputTest.Report.didPass` and `OutputTest.Report.didPass` are no longer available and `InputTest.stop()` and `OutputTest.stop()` no longer accept a `pass: boolean` parameter.
+
+Your application will need to analyze the volume levels in the `Report.values` property to determine whether or not the volume levels are acceptable.
 
 1.0.0-beta1 (July 29, 2020)
 ============================

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -2,23 +2,6 @@ import { PromiseTimedOutError } from '../errors';
 
 /**
  * @internalapi
- * Determine whether audio is silent or not by analyzing an array of volume values.
- * @param volumes An array of volume values to to analyze.
- * @returns Whether audio is silent or not.
- */
-export function detectSilence(volumes: number[]): boolean {
-  // TODO Come up with a better algorithm for deciding if the volume values
-  // resulting in a success
-
-  // Loops over every sample, checks to see if it was completely silent by
-  // checking if the average of the amplitudes is 0, and returns whether or
-  // not more than 50% of the samples were silent.
-  return !(volumes && volumes.length > 3 &&
-    (volumes.filter((v: number) => v > 0).length / volumes.length) > 0.5);
-}
-
-/**
- * @internalapi
  * Reject a promise after a specified timeout
  * @param promiseOrArray The promise to timeout.
  * @param timeoutMs The amount of time after which to reject the promise.

--- a/tests/integration/InputTest.ts
+++ b/tests/integration/InputTest.ts
@@ -61,7 +61,6 @@ describe('testInputDevice', function() {
       assert('testTiming' in report);
       assert('start' in report.testTiming!);
       assert('end' in report.testTiming!);
-      assert('didPass' in report);
       assert('testName' in report);
       assert(report.testName === InputTest.testName);
       assert('values' in report);
@@ -136,7 +135,6 @@ describe('testInputDevice', function() {
       assert('testTiming' in report);
       assert('start' in report.testTiming!);
       assert('end' in report.testTiming!);
-      assert('didPass' in report);
       assert('testName' in report);
       assert(report.testName === InputTest.testName);
       assert('values' in report);

--- a/tests/integration/OutputTest.ts
+++ b/tests/integration/OutputTest.ts
@@ -25,7 +25,6 @@ describe('testOutputDevice', function() {
         outputTestReport = await new Promise(resolve => {
           const test = testOutputDevice({
             duration: defaultTestDuration,
-            passOnTimeout: false,
             volumeEventIntervalMs: defaultTestVolumeEventIntervalMs,
           });
           test.on(OutputTest.Events.Volume, () => {
@@ -41,10 +40,6 @@ describe('testOutputDevice', function() {
         });
       });
 
-      it('should have failed', function() {
-        assert.equal(outputTestReport.didPass, false);
-      });
-
       it('should end with an `end` event', function() {
         assert.equal(
           outputTestEvents[outputTestEvents.length - 1],
@@ -53,7 +48,7 @@ describe('testOutputDevice', function() {
       });
     });
 
-    describe('when stopped with `didPass` set to `true`', function() {
+    describe('when stopped', function() {
       let outputTestReport: OutputTest.Report;
       const outputTestEvents: OutputTest.Events[] = [];
 
@@ -72,12 +67,8 @@ describe('testOutputDevice', function() {
             clearTimeout(timeoutId);
             setTimeout(() => resolve(report), defaultTestVolumeEventIntervalMs * 3);
           });
-          timeoutId = setTimeout(() => test.stop(true), defaultTestDuration);
+          timeoutId = setTimeout(() => test.stop(), defaultTestDuration);
         });
-      });
-
-      it('should pass', function() {
-        assert(outputTestReport.didPass);
       });
 
       it('should have some amount of `volume` events', function() {
@@ -100,34 +91,6 @@ describe('testOutputDevice', function() {
           1,
         );
       });
-    });
-  });
-
-  describe('when stopped with `didPass` set to `false`', function() {
-    let outputTestReport: OutputTest.Report;
-    const outputTestEvents: OutputTest.Events[] = [];
-
-    before(async function() {
-      outputTestReport = await new Promise(resolve => {
-        let timeoutId: any;
-        const test = testOutputDevice({
-          duration: Infinity,
-          volumeEventIntervalMs: defaultTestVolumeEventIntervalMs,
-        });
-        test.on(OutputTest.Events.Volume, () => {
-          outputTestEvents.push(OutputTest.Events.Volume);
-        });
-        test.on(OutputTest.Events.End, (report) => {
-          outputTestEvents.push(OutputTest.Events.End);
-          clearTimeout(timeoutId);
-          setTimeout(() => resolve(report), defaultTestVolumeEventIntervalMs * 3);
-        });
-        timeoutId = setTimeout(() => test.stop(false), defaultTestDuration);
-      });
-    });
-
-    it('should not pass', function() {
-      assert.equal(outputTestReport.didPass, false);
     });
   });
 
@@ -154,16 +117,12 @@ describe('testOutputDevice', function() {
         test.on(OutputTest.Events.Error, () => {
           outputTestEvents.push(OutputTest.Events.Error);
         });
-        timeoutId = setTimeout(() => test.stop(true), defaultTestDuration);
+        timeoutId = setTimeout(() => test.stop(), defaultTestDuration);
       });
     });
 
     it('should not have any errors', function() {
       assert.equal(outputTestReport.errors.length, 0);
-    });
-
-    it('should load the audio and pass', function() {
-      assert(outputTestReport.didPass);
     });
   });
 

--- a/tests/unit/InputTest.ts
+++ b/tests/unit/InputTest.ts
@@ -199,7 +199,6 @@ describe('testInputDevice', function() {
         assert(endHandler.calledOnce);
         const report: InputTest.Report = endHandler.args[0][0];
         assert(report);
-        assert(!report.didPass);
         assert.equal(report.values.length, volumeHandler.callCount);
         assert(report.values.every(v => v === 0));
       });
@@ -235,7 +234,6 @@ describe('testInputDevice', function() {
         assert(endHandler.calledOnce);
         const report: InputTest.Report = endHandler.args[0][0];
         assert(report);
-        assert(report.didPass);
         assert.equal(report.values.length, volumeHandler.callCount);
         assert(report.values.every(v => v === 100));
       });
@@ -261,7 +259,6 @@ describe('testInputDevice', function() {
           assert(endHandler.calledOnce);
           const report: InputTest.Report = endHandler.args[0][0];
           assert(report);
-          assert(!report.didPass);
           assert(errorHandler.calledOnce);
           assert(errorHandler.calledBefore(endHandler));
           assert(volumeHandler.notCalled);
@@ -297,7 +294,6 @@ describe('testInputDevice', function() {
         assert(handlers.end.calledOnce);
         const report: InputTest.Report = handlers.end.args[0][0];
         assert(report);
-        assert(!report.didPass);
         assert(handlers.error.calledOnce);
         assert(handlers.error.calledBefore(handlers.end));
         assert(handlers.volume.notCalled);
@@ -328,7 +324,6 @@ describe('testInputDevice', function() {
 
         const handledError = handlers.error.args[0][0];
         const report: InputTest.Report = handlers.end.args[0][0];
-        assert(!report.didPass);
         assert.equal(report.errors.length, 1);
         assert.equal(handledError, report.errors[0]);
       });
@@ -418,7 +413,6 @@ describe('testInputDevice', function() {
 
         sinon.assert.calledOnce(handlers.error);
         assert(!report.recordingUrl);
-        assert(!report.didPass);
         assert.equal(report.errors.length, 1);
         assert.equal(report.errors[0], 'foo-error');
       });


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-7906](https://issues.corp.twilio.com/browse/CLIENT-7906)

### Description

This PR removes the `didPass` report member and the `pass` parameter for the `.stop()` method from the audio device tests in order to make the "pass" criteria application specific.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
