### PR TITLE
CLIENT-8012 | Update bitrate test per latest IDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changes
 
 * The audio device tests `InputTest` and `OutputTest` no longer perform any analysis on volume data. With this change, `InputTest.Report.didPass` and `OutputTest.Report.didPass` are no longer available and `InputTest.stop()` and `OutputTest.stop()` no longer accept a `pass: boolean` parameter. Your application will need to analyze the volume levels in the `Report.values` property to determine whether or not the volume levels are acceptable.
 
-* The following classes and methods has been changed
+* The following classes and methods have been changed
 
   | Old                | New                          |
   |:-------------------|:-----------------------------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,20 @@ Changes
 
 * The audio device tests `InputTest` and `OutputTest` no longer perform any analysis on volume data. With this change, `InputTest.Report.didPass` and `OutputTest.Report.didPass` are no longer available and `InputTest.stop()` and `OutputTest.stop()` no longer accept a `pass: boolean` parameter. Your application will need to analyze the volume levels in the `Report.values` property to determine whether or not the volume levels are acceptable.
 
-* The following classes and methods for audio device tests has been changed
+* The following classes and methods has been changed
 
-  | Old                | New                     |
-  |:-------------------|:------------------------|
-  | `InputTest`        | `AudioInputTest`        |
-  | `OutputTest`       | `AudioOutputTest`       |
-  | `testInputDevice`  | `testAudioInputDevice`  |
-  | `testOutputDevice` | `testAudioOutputDevice` |
+  | Old                | New                          |
+  |:-------------------|:-----------------------------|
+  | `InputTest`        | `AudioInputTest`             |
+  | `OutputTest`       | `AudioOutputTest`            |
+  | `BitrateTest`      | `MediaConnectionBitrateTest` |
+  | `testInputDevice`  | `testAudioInputDevice`       |
+  | `testOutputDevice` | `testAudioOutputDevice`      |
+  | `testBitrate`      | `testMediaConnectionBitrate` |
+
+* `MediaConnectionBitrateTest` now uses TURN server on only one of the Peer Connections. With this change, you need to provide a STUN server in addition to the TURN server configurations. See `MediaConnectionBitrateTest.Options.iceServers` for details.
+
+* `MediaConnectionBitrateTest` no longer perform any analysis on bitrate data and `MediaConnectionBitrateTest.Report.didPass` is no longer available. Your application will need to analyze the bitrate values in `MediaConnectionBitrateTest.Report.values` and `MediaConnectionBitrateTest.Report.averageBitrate` properties to determine whether or not the values are acceptable.
 
 1.0.0-beta1 (July 29, 2020)
 ============================

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install /local-path-to-repo/rtc-diagnostics
 
 Using this method, you can import `rtc-diagnostics` like so:
 ```ts
-import { testBitrate } from '@twilio/rtc-diagnostics';
+import { testMediaConnectionBitrate } from '@twilio/rtc-diagnostics';
 ```
 
 ### Script tag
@@ -53,17 +53,17 @@ You can also include `rtc-diagnostics.js` directly in your web app using a `<scr
 
  Using this method, `rtc-diagnostics.js` will set a browser global:
  ```ts
- const { testBitrate } = Twilio.Diagnostics;
+ const { testMediaConnectionBitrate } = Twilio.Diagnostics;
  ```
 
 ## Usage
 The following are examples for running tests. For more information, please refer to the [API Docs](https://twilio.github.io/rtc-diagnostics/globals.html)
 
-### BitrateTest Example
+### MediaConnectionBitrateTest Example
 ```ts
-import { testBitrate } from '@twilio/rtc-diagnostics';
+import { testMediaConnectionBitrate } from '@twilio/rtc-diagnostics';
 
-const bitrateTest = testBitrate({
+const mediaConnectionBitrateTest = testMediaConnectionBitrate({
  iceServers: [{
    credential: 'bar',
    username: 'foo',
@@ -71,23 +71,23 @@ const bitrateTest = testBitrate({
  }],
 });
 
-bitrateTest.on('bitrate', (bitrate) => {
+mediaConnectionBitrateTest.on('bitrate', (bitrate) => {
  console.log(bitrate);
 });
 
-bitrateTest.on('error', (error) => {
+mediaConnectionBitrateTest.on('error', (error) => {
  console.log(error);
 });
 
-bitrateTest.on('end', (report) => {
+mediaConnectionBitrateTest.on('end', (report) => {
  console.log(report);
 });
 
 setTimeout(() => {
- bitrateTest.stop();
+ mediaConnectionBitrateTest.stop();
 }, 10000);
 ```
-See `BitrateTest.Options` for more information for how to obtain the `urls values`
+See `MediaConnectionBitrateTest.Options` for more information for how to obtain the `urls values`
 
 ### AudioInputTest Example
 ```ts

--- a/lib/MediaConnectionBitrateTest.ts
+++ b/lib/MediaConnectionBitrateTest.ts
@@ -243,7 +243,6 @@ export class MediaConnectionBitrateTest extends EventEmitter {
 
     const report: MediaConnectionBitrateTest.Report = {
       averageBitrate,
-      didPass: !this._errors.length && !!this._values.length && averageBitrate >= MIN_BITRATE_THRESHOLD,
       errors: this._errors,
       iceCandidateStats: this._iceCandidateStats,
       testName: MediaConnectionBitrateTest.testName,
@@ -465,13 +464,6 @@ export namespace MediaConnectionBitrateTest {
      * Average bitrate calculated during the test.
      */
     averageBitrate: number;
-
-    /**
-     * Whether or not the test passed.
-     * The test is considered to be passing if there were no errors detected and average bitrate is greater than the minimum bitrate required to make a call.
-     * See [Network Bandwidth Requirements](https://www.twilio.com/docs/voice/client/javascript/voice-client-js-and-mobile-sdks-network-connectivity-requirements#network-bandwidth-requirements)
-     */
-    didPass: boolean;
 
     /**
      * Any errors that occurred during the test.

--- a/lib/MediaConnectionBitrateTest.ts
+++ b/lib/MediaConnectionBitrateTest.ts
@@ -15,55 +15,55 @@ import {
   RTCSelectedIceCandidatePairStats,
 } from './utils/candidate';
 
-export declare interface BitrateTest {
+export declare interface MediaConnectionBitrateTest {
   /**
    * Raised every second with a `bitrate` parameter in kbps which represents the connection's bitrate since the last time this event was raised.
    * The bitrate value is limited by either your downlink or uplink, whichever is lower.
    * For example, if your downlink and uplink is 50mbps and 10mbps respectively, bitrate value will not exceed 10mbps.
-   * @param event [[BitrateTest.Events.Bitrate]].
+   * @param event [[MediaConnectionBitrateTest.Events.Bitrate]].
    * @param listener A callback with a `bitrate`(kbps) parameter since the last time this event was raised.
-   * @returns This [[BitrateTest]] instance.
+   * @returns This [[MediaConnectionBitrateTest]] instance.
    * @event
    */
   on(
-    event: BitrateTest.Events.Bitrate,
+    event: MediaConnectionBitrateTest.Events.Bitrate,
     listener: (bitrate: number) => any,
   ): this;
 
   /**
    * Raised when the test encounters an error.
-   * When this happens, the test will immediately stop and emit [[BitrateTest.Events.End]].
-   * @param event [[BitrateTest.Events.Error]].
+   * When this happens, the test will immediately stop and emit [[MediaConnectionBitrateTest.Events.End]].
+   * @param event [[MediaConnectionBitrateTest.Events.Error]].
    * @param listener A callback with a [[DiagnosticError]] parameter.
-   * @returns This [[BitrateTest]] instance.
+   * @returns This [[MediaConnectionBitrateTest]] instance.
    * @event
    */
   on(
-    event: BitrateTest.Events.Error,
+    event: MediaConnectionBitrateTest.Events.Error,
     listener: (error: DiagnosticError) => any,
   ): this;
 
   /**
    * Raised upon completion of the test.
-   * @param event [[BitrateTest.Events.End]].
-   * @param listener A callback with a [[BitrateTest.Report]] parameter.
-   * @returns This [[BitrateTest]] instance.
+   * @param event [[MediaConnectionBitrateTest.Events.End]].
+   * @param listener A callback with a [[MediaConnectionBitrateTest.Report]] parameter.
+   * @returns This [[MediaConnectionBitrateTest]] instance.
    * @event
    */
   on(
-    event: BitrateTest.Events.End,
-    listener: (report: BitrateTest.Report) => any,
+    event: MediaConnectionBitrateTest.Events.End,
+    listener: (report: MediaConnectionBitrateTest.Report) => any,
   ): this;
 }
 
 /**
- * BitrateTest uses two [RTCPeerConnections](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection)
+ * MediaConnectionBitrateTest uses two [RTCPeerConnections](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection)
  * connected via a [Twilio Network Traversal Service](https://www.twilio.com/docs/stun-turn).
  * Using [RTCDataChannel](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel), one RTCPeerConnection will saturate the data channel buffer and will
  * constantly send data packets to the other RTCPeerConnection. The receiving peer will measure the bitrate base on the amount of packets received every second.
- * See [[BitrateTest.Options.iceServers]] for information how to use Twilio NTS.
+ * See [[MediaConnectionBitrateTest.Options.iceServers]] for information how to use Twilio NTS.
  */
-export class BitrateTest extends EventEmitter {
+export class MediaConnectionBitrateTest extends EventEmitter {
   /**
    * Name of this test
    */
@@ -100,9 +100,9 @@ export class BitrateTest extends EventEmitter {
   private _lastCheckedTimestamp: number = 0;
 
   /**
-   * The options passed to [[BitrateTest]] constructor.
+   * The options passed to [[MediaConnectionBitrateTest]] constructor.
    */
-  private _options: BitrateTest.ExtendedOptions;
+  private _options: MediaConnectionBitrateTest.ExtendedOptions;
 
   /**
    * The RTCPeerConnection that will receive data
@@ -142,7 +142,7 @@ export class BitrateTest extends EventEmitter {
 
   /**
    * Timeout reference that should be cleared when we receive any data. If this
-   * times out, it means something has timed out our BitrateTest.
+   * times out, it means something has timed out our [[MediaConnectionBitrateTest]].
    */
   private _timeout: NodeJS.Timer;
 
@@ -157,12 +157,12 @@ export class BitrateTest extends EventEmitter {
   private _values: number[] = [];
 
   /**
-   * Construct a [[BitrateTest]] instance. The test will start immediately.
-   * Test should be allowed to run for a minimum of 8 seconds. To stop the test, call [[BitrateTest.stop]].
+   * Construct a [[MediaConnectionBitrateTest]] instance. The test will start immediately.
+   * Test should be allowed to run for a minimum of 8 seconds. To stop the test, call [[MediaConnectionBitrateTest.stop]].
    * @constructor
    * @param options
    */
-  constructor(options: BitrateTest.ExtendedOptions) {
+  constructor(options: MediaConnectionBitrateTest.ExtendedOptions) {
     super();
 
     this._options = { ...options };
@@ -203,7 +203,7 @@ export class BitrateTest extends EventEmitter {
       this._pcReceiver.close();
       this._endTime = Date.now();
 
-      this.emit(BitrateTest.Events.End, this._getReport());
+      this.emit(MediaConnectionBitrateTest.Events.End, this._getReport());
     }
   }
 
@@ -229,13 +229,13 @@ export class BitrateTest extends EventEmitter {
     this._lastCheckedTimestamp = now;
     this._lastBytesChecked = this._totalBytesReceived;
     this._values.push(bitrate);
-    this.emit(BitrateTest.Events.Bitrate, bitrate);
+    this.emit(MediaConnectionBitrateTest.Events.Bitrate, bitrate);
   }
 
   /**
    * Generate and returns the report for this test
    */
-  private _getReport(): BitrateTest.Report {
+  private _getReport(): MediaConnectionBitrateTest.Report {
     let averageBitrate = this._values
       .reduce((total: number, value: number) => total += value, 0) / this._values.length;
     averageBitrate = isNaN(averageBitrate) ? 0 : averageBitrate;
@@ -246,12 +246,12 @@ export class BitrateTest extends EventEmitter {
       testTiming.duration = this._endTime - this._startTime;
     }
 
-    const report: BitrateTest.Report = {
+    const report: MediaConnectionBitrateTest.Report = {
       averageBitrate,
       didPass: !this._errors.length && !!this._values.length && averageBitrate >= MIN_BITRATE_THRESHOLD,
       errors: this._errors,
       iceCandidateStats: this._iceCandidateStats,
-      testName: BitrateTest.testName,
+      testName: MediaConnectionBitrateTest.testName,
       testTiming,
       values: this._values,
     };
@@ -272,7 +272,7 @@ export class BitrateTest extends EventEmitter {
   private _onError(message: string, error?: DOMError): void {
     const diagnosticError = new DiagnosticError(error, message);
     this._errors.push(diagnosticError);
-    this.emit(BitrateTest.Events.Error, diagnosticError);
+    this.emit(MediaConnectionBitrateTest.Events.Error, diagnosticError);
     this.stop();
   }
 
@@ -395,9 +395,9 @@ export class BitrateTest extends EventEmitter {
   }
 }
 
-export namespace BitrateTest {
+export namespace MediaConnectionBitrateTest {
   /**
-   * Possible events that a [[BitrateTest]] might emit. See [[BitrateTest.on]].
+   * Possible events that a [[MediaConnectionBitrateTest]] might emit. See [[MediaConnectionBitrateTest.on]].
    */
   export enum Events {
     Bitrate = 'bitrate',
@@ -406,7 +406,7 @@ export namespace BitrateTest {
   }
 
   /**
-   * Options that may be passed to [[BitrateTest]] constructor for internal testing.
+   * Options that may be passed to [[MediaConnectionBitrateTest]] constructor for internal testing.
    * @internalapi
    */
   export interface ExtendedOptions extends Options {
@@ -418,7 +418,7 @@ export namespace BitrateTest {
   }
 
   /**
-   * Options passed to [[BitrateTest]] constructor.
+   * Options passed to [[MediaConnectionBitrateTest]] constructor.
    */
   export interface Options {
     /**
@@ -432,7 +432,7 @@ export namespace BitrateTest {
      *
      * ```ts
      * import Client from 'twilio';
-     * import { testBitrate } from '@twilio/rtc-diagnostics';
+     * import { testMediaConnectionBitrate } from '@twilio/rtc-diagnostics';
      *
      * // Generate the STUN and TURN server credentials with a ttl of 120 seconds
      * const client = Client(twilioAccountSid, authToken);
@@ -451,7 +451,7 @@ export namespace BitrateTest {
      * urls = urls.replace('global', 'ashburn');
      *
      * // Use the TURN credentials using the iceServers parameter
-     * const bitrateTest = testBitrate({ iceServers: [{ urls, username, credential }] });
+     * const mediaConnectionBitrateTest = testMediaConnectionBitrate({ iceServers: [{ urls, username, credential }] });
      * ```
      * Note, for production code, the above code should not be executed client side as it requires the authToken which must be treated like a private key.
      */
@@ -459,7 +459,7 @@ export namespace BitrateTest {
   }
 
   /**
-   * Represents the report generated from a [[BitrateTest]].
+   * Represents the report generated from a [[MediaConnectionBitrateTest]].
    */
   export interface Report {
     /**
@@ -513,9 +513,9 @@ export namespace BitrateTest {
  *
  * Example:
  * ```ts
- *   import { testBitrate } from '@twilio/rtc-diagnostics';
+ *   import { testMediaConnectionBitrate } from '@twilio/rtc-diagnostics';
  *
- *   const bitrateTest = testBitrate({
+ *   const mediaConnectionBitrateTest = testMediaConnectionBitrate({
  *     iceServers: [{
  *       credential: 'bar',
  *       username: 'foo',
@@ -523,25 +523,25 @@ export namespace BitrateTest {
  *     }],
  *   });
  *
- *   bitrateTest.on('bitrate', (bitrate) => {
+ *   mediaConnectionBitrateTest.on('bitrate', (bitrate) => {
  *     console.log(bitrate);
  *   });
  *
- *   bitrateTest.on('error', (error) => {
+ *   mediaConnectionBitrateTest.on('error', (error) => {
  *     console.log(error);
  *   });
  *
- *   bitrateTest.on('end', (report) => {
+ *   mediaConnectionBitrateTest.on('end', (report) => {
  *     console.log(report);
  *   });
  *
  *   // Run the test for 15 seconds
  *   setTimeout(() => {
- *     bitrateTest.stop();
+ *     mediaConnectionBitrateTest.stop();
  *   }, 15000);
  * ```
- * See [[BitrateTest.Options.iceServers]] for details on how to obtain TURN credentials.
+ * See [[MediaConnectionBitrateTest.Options.iceServers]] for details on how to obtain TURN credentials.
  */
-export function testBitrate(options: BitrateTest.Options): BitrateTest {
-  return new BitrateTest(options);
+export function testMediaConnectionBitrate(options: MediaConnectionBitrateTest.Options): MediaConnectionBitrateTest {
+  return new MediaConnectionBitrateTest(options);
 }

--- a/lib/diagnostics.ts
+++ b/lib/diagnostics.ts
@@ -1,7 +1,7 @@
 import { AudioInputTest, testAudioInputDevice } from './AudioInputTest';
 import { AudioOutputTest, testAudioOutputDevice } from './AudioOutputTest';
-import { BitrateTest, testBitrate } from './BitrateTest';
 import { ErrorName, WarningName } from './constants';
+import { MediaConnectionBitrateTest, testMediaConnectionBitrate } from './MediaConnectionBitrateTest';
 
 /**
  * @internalapi
@@ -25,7 +25,7 @@ window.Twilio.Diagnostics = {
   ...window.Twilio.Diagnostics,
   testAudioInputDevice,
   testAudioOutputDevice,
-  testBitrate,
+  testMediaConnectionBitrate,
 };
 
 /**
@@ -34,10 +34,10 @@ window.Twilio.Diagnostics = {
 export {
   AudioInputTest,
   AudioOutputTest,
-  BitrateTest,
+  MediaConnectionBitrateTest,
   ErrorName,
   testAudioInputDevice,
   testAudioOutputDevice,
-  testBitrate,
+  testMediaConnectionBitrate,
   WarningName,
 };

--- a/tests/unit/MediaConnectionBitrateTest.ts
+++ b/tests/unit/MediaConnectionBitrateTest.ts
@@ -90,6 +90,16 @@ describe('MediaConnectionBitrateTest', () => {
       assert.deepEqual(pcReceiverContext.rtcConfiguration.iceServers, iceServers);
       assert.deepEqual(pcSenderContext.rtcConfiguration.iceServers, iceServers);
     });
+
+    it('should use relay on the receiving peer connection', () => {
+      mediaConnectionBitrateTest = new MediaConnectionBitrateTest(options);
+      assert.equal(pcReceiverContext.rtcConfiguration.iceTransportPolicy, 'relay');
+    });
+
+    it('should not use relay on the sending peer connection', () => {
+      mediaConnectionBitrateTest = new MediaConnectionBitrateTest(options);
+      assert.equal(pcSenderContext.rtcConfiguration.iceTransportPolicy, undefined);
+    });
   });
 
   describe('onicecandidate', () => {
@@ -118,12 +128,6 @@ describe('MediaConnectionBitrateTest', () => {
         sinon.assert.notCalled(pcSenderContext.addIceCandidate);
       });
 
-      it('should not add ICE candidate if candidate is not relay', () => {
-        event.candidate.candidate = candidateHost;
-        pcReceiverContext.onicecandidate(event);
-        sinon.assert.notCalled(pcSenderContext.addIceCandidate);
-      });
-
       it('should emit error on addIceCandidate failure', () => {
         pcSenderContext.addIceCandidate = () => ({
           catch: (cb: Function) => {
@@ -147,12 +151,6 @@ describe('MediaConnectionBitrateTest', () => {
 
       it('should not add ICE candidate if candidate event is empty', () => {
         pcSenderContext.onicecandidate({});
-        sinon.assert.notCalled(pcReceiverContext.addIceCandidate);
-      });
-
-      it('should not add ICE candidate if candidate is not relay', () => {
-        event.candidate.candidate = candidateHost;
-        pcSenderContext.onicecandidate(event);
         sinon.assert.notCalled(pcReceiverContext.addIceCandidate);
       });
 

--- a/tests/unit/MediaConnectionBitrateTest.ts
+++ b/tests/unit/MediaConnectionBitrateTest.ts
@@ -2,11 +2,11 @@ import * as assert from 'assert';
 import { EventEmitter } from 'events';
 import * as sinon from 'sinon';
 import { SinonFakeTimers } from 'sinon';
-import { BitrateTest, testBitrate } from '../../lib/BitrateTest';
 import { ErrorName } from '../../lib/constants';
 import { DiagnosticError } from '../../lib/errors/DiagnosticError';
+import { MediaConnectionBitrateTest, testMediaConnectionBitrate } from '../../lib/MediaConnectionBitrateTest';
 
-describe('BitrateTest', () => {
+describe('MediaConnectionBitrateTest', () => {
   const root = (global as any);
   const iceServers = [{
     credential: 'bar',
@@ -15,7 +15,7 @@ describe('BitrateTest', () => {
     username: 'foo',
   }];
 
-  let bitrateTest: BitrateTest;
+  let mediaConnectionBitrateTest: MediaConnectionBitrateTest;
   let originalRTCPeerConnection: any;
   let options: any;
   let pcReceiverContext: any;
@@ -72,21 +72,21 @@ describe('BitrateTest', () => {
     pcReceiverContext = null;
     pcSenderContext = null;
     root.RTCPeerConnection = originalRTCPeerConnection;
-    if (bitrateTest) {
-      bitrateTest.stop();
+    if (mediaConnectionBitrateTest) {
+      mediaConnectionBitrateTest.stop();
     }
   });
 
-  describe('testBitrate', () => {
-    it('should return BitrateTest instance', () => {
-      bitrateTest = testBitrate(options);
-      assert(!!bitrateTest);
+  describe('testMediaConnectionBitrate', () => {
+    it('should return MediaConnectionBitrateTest instance', () => {
+      mediaConnectionBitrateTest = testMediaConnectionBitrate(options);
+      assert(!!mediaConnectionBitrateTest);
     });
   });
 
   describe('constructor', () => {
     it('should use iceServers option', () => {
-      bitrateTest = new BitrateTest(options);
+      mediaConnectionBitrateTest = new MediaConnectionBitrateTest(options);
       assert.deepEqual(pcReceiverContext.rtcConfiguration.iceServers, iceServers);
       assert.deepEqual(pcSenderContext.rtcConfiguration.iceServers, iceServers);
     });
@@ -104,7 +104,7 @@ describe('BitrateTest', () => {
           candidate: candidateRelay,
         },
       };
-      bitrateTest = new BitrateTest(options);
+      mediaConnectionBitrateTest = new MediaConnectionBitrateTest(options);
     });
 
     context('receiver pc', () => {
@@ -133,7 +133,7 @@ describe('BitrateTest', () => {
 
         setTimeout(() => pcReceiverContext.onicecandidate(event));
 
-        return expectEvent('error', bitrateTest).then((result: any) => {
+        return expectEvent('error', mediaConnectionBitrateTest).then((result: any) => {
           assert.equal(result.domError, 'foo');
         });
       });
@@ -165,7 +165,7 @@ describe('BitrateTest', () => {
 
         setTimeout(() => pcSenderContext.onicecandidate(event));
 
-        return expectEvent('error', bitrateTest).then((result: any) => {
+        return expectEvent('error', mediaConnectionBitrateTest).then((result: any) => {
           assert.equal(result.domError, 'foo');
         });
       });
@@ -176,79 +176,79 @@ describe('BitrateTest', () => {
     const wait = () => new Promise(r => setTimeout(r, 1));
 
     beforeEach(() => {
-      bitrateTest = new BitrateTest(options);
-      bitrateTest.stop = sinon.spy(bitrateTest.stop);
+      mediaConnectionBitrateTest = new MediaConnectionBitrateTest(options);
+      mediaConnectionBitrateTest.stop = sinon.spy(mediaConnectionBitrateTest.stop);
     });
 
     it('should throw error on createOffer failure', () => {
       const callback = sinon.spy();
-      bitrateTest.on(BitrateTest.Events.Error, callback);
+      mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, callback);
       pcSenderContext.createOffer = () => Promise.reject('foo');
 
       return wait().then(() => {
         sinon.assert.calledWith(callback, sinon.match.has('domError', 'foo'));
         sinon.assert.calledWith(callback, sinon.match.has('message', 'Unable to create offer'));
-        sinon.assert.called(bitrateTest.stop as any);
+        sinon.assert.called(mediaConnectionBitrateTest.stop as any);
       });
     });
 
     it('should throw error on sender setLocalDescription failure', () => {
       const callback = sinon.spy();
-      bitrateTest.on(BitrateTest.Events.Error, callback);
+      mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, callback);
       pcSenderContext.setLocalDescription = () => Promise.reject('foo');
 
       return wait().then(() => {
         sinon.assert.calledWith(callback, sinon.match.has('domError', 'foo'));
         sinon.assert.calledWith(callback, sinon.match.has('message', 'Unable to set local or remote description from createOffer'));
-        sinon.assert.called(bitrateTest.stop as any);
+        sinon.assert.called(mediaConnectionBitrateTest.stop as any);
       });
     });
 
     it('should throw error on receiver setRemoteDescription failure', () => {
       const callback = sinon.spy();
-      bitrateTest.on(BitrateTest.Events.Error, callback);
+      mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, callback);
       pcReceiverContext.setRemoteDescription = () => Promise.reject('foo');
 
       return wait().then(() => {
         sinon.assert.calledWith(callback, sinon.match.has('domError', 'foo'));
         sinon.assert.calledWith(callback, sinon.match.has('message', 'Unable to set local or remote description from createOffer'));
-        sinon.assert.called(bitrateTest.stop as any);
+        sinon.assert.called(mediaConnectionBitrateTest.stop as any);
       });
     });
 
     it('should throw error on createAnswer failure', () => {
       const callback = sinon.spy();
-      bitrateTest.on(BitrateTest.Events.Error, callback);
+      mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, callback);
       pcReceiverContext.createAnswer = () => Promise.reject('foo');
 
       return wait().then(() => {
         sinon.assert.calledWith(callback, sinon.match.has('domError', 'foo'));
         sinon.assert.calledWith(callback, sinon.match.has('message', 'Unable to create answer'));
-        sinon.assert.called(bitrateTest.stop as any);
+        sinon.assert.called(mediaConnectionBitrateTest.stop as any);
       });
     });
 
     it('should throw error on receiver setLocalDescription failure', () => {
       const callback = sinon.spy();
-      bitrateTest.on(BitrateTest.Events.Error, callback);
+      mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, callback);
       pcReceiverContext.setLocalDescription = () => Promise.reject('foo');
 
       return wait().then(() => {
         sinon.assert.calledWith(callback, sinon.match.has('domError', 'foo'));
         sinon.assert.calledWith(callback, sinon.match.has('message', 'Unable to set local or remote description from createAnswer'));
-        sinon.assert.called(bitrateTest.stop as any);
+        sinon.assert.called(mediaConnectionBitrateTest.stop as any);
       });
     });
 
     it('should throw error on sender setRemoteDescription failure', () => {
       const callback = sinon.spy();
-      bitrateTest.on(BitrateTest.Events.Error, callback);
+      mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, callback);
       pcSenderContext.setRemoteDescription = () => Promise.reject('foo');
 
       return wait().then(() => {
         sinon.assert.calledWith(callback, sinon.match.has('domError', 'foo'));
         sinon.assert.calledWith(callback, sinon.match.has('message', 'Unable to set local or remote description from createAnswer'));
-        sinon.assert.called(bitrateTest.stop as any);
+        sinon.assert.called(mediaConnectionBitrateTest.stop as any);
       });
     });
   });
@@ -258,8 +258,8 @@ describe('BitrateTest', () => {
 
     beforeEach(() => {
       clock = sinon.useFakeTimers(0);
-      bitrateTest = new BitrateTest(options);
-      bitrateTest.stop = sinon.spy(bitrateTest.stop);
+      mediaConnectionBitrateTest = new MediaConnectionBitrateTest(options);
+      mediaConnectionBitrateTest.stop = sinon.spy(mediaConnectionBitrateTest.stop);
     });
 
     afterEach(() => {
@@ -268,9 +268,9 @@ describe('BitrateTest', () => {
 
     it('should emit error on createDataChannel failure', (done) => {
       pcSenderContext.createDataChannel = () => { throw new Error(); };
-      bitrateTest.on(BitrateTest.Events.Error, (error: DiagnosticError) => {
+      mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, (error: DiagnosticError) => {
         assert.equal(error.message, 'Error creating data channel');
-        sinon.assert.notCalled(bitrateTest.stop as any);
+        sinon.assert.notCalled(mediaConnectionBitrateTest.stop as any);
         done();
       });
       clock.tick(1);
@@ -281,13 +281,13 @@ describe('BitrateTest', () => {
         rtcDataChannel.readyState = 'open';
 
         let errorName: string = '';
-        bitrateTest.on(BitrateTest.Events.Error, (error: DiagnosticError) => {
+        mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, (error: DiagnosticError) => {
           errorName = error.name;
         });
 
         clock.tick(15100);
 
-        sinon.assert.calledOnce(bitrateTest.stop as any);
+        sinon.assert.calledOnce(mediaConnectionBitrateTest.stop as any);
         assert.equal(errorName, ErrorName.DiagnosticError);
       });
     });
@@ -340,7 +340,7 @@ describe('BitrateTest', () => {
 
         beforeEach(() => {
           clock = sinon.useFakeTimers(0);
-          bitrateTest = new BitrateTest(options);
+          mediaConnectionBitrateTest = new MediaConnectionBitrateTest(options);
           clock.tick(1);
           dataChannelEvent = {
             channel: {
@@ -358,7 +358,7 @@ describe('BitrateTest', () => {
 
         it('should not emit bitrate if no sample data is available', () => {
           const callback = sinon.stub();
-          bitrateTest.on(BitrateTest.Events.Bitrate, callback);
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Bitrate, callback);
 
           sendMessage(message);
           clock.tick(1000);
@@ -368,7 +368,7 @@ describe('BitrateTest', () => {
 
         it('should emit bitrate', () => {
           const callback = sinon.stub();
-          bitrateTest.on(BitrateTest.Events.Bitrate, callback);
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Bitrate, callback);
 
           sendMessage(message);
           clock.tick(1500);
@@ -382,7 +382,7 @@ describe('BitrateTest', () => {
 
         it('should stop emitting bitrate on stop', () => {
           const callback = sinon.stub();
-          bitrateTest.on(BitrateTest.Events.Bitrate, callback);
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Bitrate, callback);
 
           sendMessage(message);
           clock.tick(1200);
@@ -390,7 +390,7 @@ describe('BitrateTest', () => {
           sendMessage(message);
           clock.tick(1200);
 
-          bitrateTest.stop();
+          mediaConnectionBitrateTest.stop();
           sendMessage(message);
           clock.tick(1200);
 
@@ -399,7 +399,7 @@ describe('BitrateTest', () => {
 
         it('should emit end event on stop', () => {
           const callback = sinon.stub();
-          bitrateTest.on(BitrateTest.Events.End, callback);
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, callback);
           sendMessage(message);
           clock.tick(1200);
           sendMessage(message);
@@ -407,15 +407,15 @@ describe('BitrateTest', () => {
           sendMessage(message);
           clock.tick(1200);
 
-          bitrateTest.stop();
+          mediaConnectionBitrateTest.stop();
           sinon.assert.calledOnce(callback);
         });
 
         it('should generate a report', (done) => {
           const values: number[] = [];
-          bitrateTest.on(BitrateTest.Events.Bitrate, (bitrate: number) => values.push(bitrate));
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Bitrate, (bitrate: number) => values.push(bitrate));
 
-          bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
             assert.deepStrictEqual(report, {
               averageBitrate: values.reduce((total: number, value: number) => total += value, 0) / values.length,
               didPass: false,
@@ -439,53 +439,53 @@ describe('BitrateTest', () => {
           sendMessage(message);
           clock.tick(1200);
 
-          bitrateTest.stop();
+          mediaConnectionBitrateTest.stop();
         });
 
         it('should fail if average bitrate is below minimum', (done) => {
-          bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
             assert(!report.didPass);
             done();
           });
 
           sendMessage(message);
           clock.tick(1200);
-          bitrateTest['_values'] = [99, 99, 99];
-          bitrateTest.stop();
+          mediaConnectionBitrateTest['_values'] = [99, 99, 99];
+          mediaConnectionBitrateTest.stop();
         });
 
         it('should pass if average bitrate is above minimum', (done) => {
-          bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
             assert(report.didPass);
             done();
           });
 
           sendMessage(message);
           clock.tick(1200);
-          bitrateTest['_values'] = [101, 101, 101];
-          bitrateTest.stop();
+          mediaConnectionBitrateTest['_values'] = [101, 101, 101];
+          mediaConnectionBitrateTest.stop();
         });
 
         it('should pass if average bitrate is exactly equal to minimum', (done) => {
-          bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
             assert(report.didPass);
             done();
           });
 
           sendMessage(message);
           clock.tick(1200);
-          bitrateTest['_values'] = [100, 100, 100];
-          bitrateTest.stop();
+          mediaConnectionBitrateTest['_values'] = [100, 100, 100];
+          mediaConnectionBitrateTest.stop();
         });
 
         it('should not pass test if no values are found', (done) => {
-          bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
             assert.deepStrictEqual(report.didPass, false);
             done();
           });
 
           clock.tick(4000);
-          bitrateTest.stop();
+          mediaConnectionBitrateTest.stop();
         });
 
         it('should include errors in a report', (done) => {
@@ -495,9 +495,9 @@ describe('BitrateTest', () => {
             },
           });
           const errors: DiagnosticError[] = [];
-          bitrateTest.on(BitrateTest.Events.Error, (error: DiagnosticError) => errors.push(error));
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, (error: DiagnosticError) => errors.push(error));
 
-          bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
+          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
             assert.deepStrictEqual(report.errors, errors);
             assert.deepStrictEqual(report.didPass, false);
             done();
@@ -519,7 +519,7 @@ describe('BitrateTest', () => {
         });
 
         describe('ICE Candidate Stats', () => {
-          const runBitrateTest = (shouldStop: boolean) => {
+          const runMediaConnectionBitrateTest = (shouldStop: boolean) => {
             ['new', 'checking', 'connected', 'completed', 'disconnected', 'closed'].forEach(state => {
               pcSenderContext.iceConnectionState = state;
               pcSenderContext.oniceconnectionstatechange();
@@ -531,12 +531,12 @@ describe('BitrateTest', () => {
             sendMessage(message);
 
             if (shouldStop) {
-              bitrateTest.stop();
+              mediaConnectionBitrateTest.stop();
             }
           };
 
           it('should include ICE Candidate stats in the report', (done) => {
-            bitrateTest = new BitrateTest({
+            mediaConnectionBitrateTest = new MediaConnectionBitrateTest({
               ...options,
               getRTCIceCandidateStatsReport: () => ({then: (cb: Function) => {
                 cb({
@@ -550,7 +550,7 @@ describe('BitrateTest', () => {
               }}),
             });
 
-            bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
+            mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
               assert.deepStrictEqual(report.iceCandidateStats, ['foo', 'bar']);
               assert.deepStrictEqual(report.selectedIceCandidatePairStats, {
                 localCandidate: 'foo',
@@ -559,11 +559,11 @@ describe('BitrateTest', () => {
               done();
             });
 
-            runBitrateTest(true);
+            runMediaConnectionBitrateTest(true);
           });
 
           it('should not include selected ICE Candidate stats in the report if no candidates were selected', (done) => {
-            bitrateTest = new BitrateTest({
+            mediaConnectionBitrateTest = new MediaConnectionBitrateTest({
               ...options,
               getRTCIceCandidateStatsReport: () => ({then: (cb: Function) => {
                 cb({
@@ -573,17 +573,17 @@ describe('BitrateTest', () => {
               }}),
             });
 
-            bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
+            mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
               assert.deepStrictEqual(report.iceCandidateStats, ['foo', 'bar']);
               assert(!report.selectedIceCandidatePairStats);
               done();
             });
 
-            runBitrateTest(true);
+            runMediaConnectionBitrateTest(true);
           });
 
           it('should fail the test if stats are not available', (done) => {
-            bitrateTest = new BitrateTest({
+            mediaConnectionBitrateTest = new MediaConnectionBitrateTest({
               ...options,
               getRTCIceCandidateStatsReport: () => ({then: () => {
                 return {catch: (cb: Function) => {
@@ -593,16 +593,16 @@ describe('BitrateTest', () => {
             });
 
             const onError = sinon.stub();
-            bitrateTest.on(BitrateTest.Events.Error, onError);
+            mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.Error, onError);
 
-            bitrateTest.on(BitrateTest.Events.End, (report: BitrateTest.Report) => {
+            mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
               sinon.assert.calledOnce(onError);
               assert(!report.didPass);
               assert.equal(report.errors[0].domError, 'Foo error');
               done();
             });
 
-            runBitrateTest(false);
+            runMediaConnectionBitrateTest(false);
           });
         });
       });

--- a/tests/unit/MediaConnectionBitrateTest.ts
+++ b/tests/unit/MediaConnectionBitrateTest.ts
@@ -416,7 +416,6 @@ describe('MediaConnectionBitrateTest', () => {
           mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
             assert.deepStrictEqual(report, {
               averageBitrate: values.reduce((total: number, value: number) => total += value, 0) / values.length,
-              didPass: false,
               errors: [],
               iceCandidateStats: [],
               testName: 'bitrate-test',
@@ -440,52 +439,6 @@ describe('MediaConnectionBitrateTest', () => {
           mediaConnectionBitrateTest.stop();
         });
 
-        it('should fail if average bitrate is below minimum', (done) => {
-          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
-            assert(!report.didPass);
-            done();
-          });
-
-          sendMessage(message);
-          clock.tick(1200);
-          mediaConnectionBitrateTest['_values'] = [99, 99, 99];
-          mediaConnectionBitrateTest.stop();
-        });
-
-        it('should pass if average bitrate is above minimum', (done) => {
-          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
-            assert(report.didPass);
-            done();
-          });
-
-          sendMessage(message);
-          clock.tick(1200);
-          mediaConnectionBitrateTest['_values'] = [101, 101, 101];
-          mediaConnectionBitrateTest.stop();
-        });
-
-        it('should pass if average bitrate is exactly equal to minimum', (done) => {
-          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
-            assert(report.didPass);
-            done();
-          });
-
-          sendMessage(message);
-          clock.tick(1200);
-          mediaConnectionBitrateTest['_values'] = [100, 100, 100];
-          mediaConnectionBitrateTest.stop();
-        });
-
-        it('should not pass test if no values are found', (done) => {
-          mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
-            assert.deepStrictEqual(report.didPass, false);
-            done();
-          });
-
-          clock.tick(4000);
-          mediaConnectionBitrateTest.stop();
-        });
-
         it('should include errors in a report', (done) => {
           pcSenderContext.addIceCandidate = () => ({
             catch: (cb: Function) => {
@@ -497,7 +450,6 @@ describe('MediaConnectionBitrateTest', () => {
 
           mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
             assert.deepStrictEqual(report.errors, errors);
-            assert.deepStrictEqual(report.didPass, false);
             done();
           });
 
@@ -595,7 +547,6 @@ describe('MediaConnectionBitrateTest', () => {
 
             mediaConnectionBitrateTest.on(MediaConnectionBitrateTest.Events.End, (report: MediaConnectionBitrateTest.Report) => {
               sinon.assert.calledOnce(onError);
-              assert(!report.didPass);
               assert.equal(report.errors[0].domError, 'Foo error');
               done();
             });

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -1,5 +1,5 @@
 /**
- * The following rule is necessary as having `BitrateTest` imported first causes
+ * The following rule is necessary as having `MediaConnectionBitrateTest` imported first causes
  * unit tests to crash.
  */
 /* tslint:disable ordered-imports */
@@ -19,4 +19,4 @@ import './recorder/encoder';
 // Diagnostics tests
 import './AudioInputTest';
 import './AudioOutputTest';
-import './BitrateTest';
+import './MediaConnectionBitrateTest';


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-8012](https://issues.corp.twilio.com/browse/CLIENT-8012)

### Description
Please see commit history if it's easier to review the diffs.

- Rename BitrateTest to MediaConnectionBitrateTest
- Update bitrate test to use relay on only one of the peer connections.
- Remove didPass from MediaConnectionBitrateTest.Report

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
