### PR TITLE
Fix travis leak

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -23,7 +23,7 @@
         "git tag ${RELEASE_VERSION}",
         "git remote set-url origin \"https://${GH_TOKEN}@${GH_REF}\"",
         "git rebase HEAD ${BRANCH}",
-        "git push origin ${BRANCH} --tags",
+        "git push origin ${BRANCH} --tags &> /dev/null && echo \"Push to origin successful\" || (echo \"Push to origin failed\" 1>&2 && exit 1)",
         "git fetch --all",
         "git checkout ${RELEASE_VERSION}",
         "git rm -rf docs",


### PR DESCRIPTION
This PR makes sure we don't output GH tokens when the git command fails. The script does:
- hides all git push output
- if push is successful, it prints "Push to origin successful"
- if push failed, it prints "Push to origin failed" and exits non-zero code

The issue we're solving however, is not happening anymore because latest version of release-tool doesn't output the errors anymore. This PR is another layer to hide the output in case release-tool is updated to show verbose logging.