### PR TITLE
[CLIENT-8061] Catch `gUM` errors in FF.

### DIFF
--- a/lib/AudioInputTest.ts
+++ b/lib/AudioInputTest.ts
@@ -511,6 +511,13 @@ export class AudioInputTest extends EventEmitter {
           error,
           'A `DOMError` has occurred.',
         ));
+      } else if (
+        typeof Error !== 'undefined' && error instanceof Error
+      ) {
+        this._onError(new DiagnosticError(
+          error,
+          'An `Error` has occurred.',
+        ));
       } else {
         this._onError(new DiagnosticError(
           undefined,

--- a/lib/AudioInputTest.ts
+++ b/lib/AudioInputTest.ts
@@ -516,7 +516,7 @@ export class AudioInputTest extends EventEmitter {
       ) {
         this._onError(new DiagnosticError(
           error,
-          'An `Error` has occurred.',
+          'An error has occurred.',
         ));
       } else {
         this._onError(new DiagnosticError(

--- a/lib/AudioOutputTest.ts
+++ b/lib/AudioOutputTest.ts
@@ -410,6 +410,13 @@ export class AudioOutputTest extends EventEmitter {
           error,
           'A DOMError has occurred.',
         ));
+      } else if (
+        typeof Error !== 'undefined' && error instanceof Error
+      ) {
+        this._onError(new DiagnosticError(
+          error,
+          'An `Error` has occurred.',
+        ));
       } else {
         this._onError(new DiagnosticError(
           undefined,

--- a/lib/AudioOutputTest.ts
+++ b/lib/AudioOutputTest.ts
@@ -415,7 +415,7 @@ export class AudioOutputTest extends EventEmitter {
       ) {
         this._onError(new DiagnosticError(
           error,
-          'An `Error` has occurred.',
+          'An error has occurred.',
         ));
       } else {
         this._onError(new DiagnosticError(

--- a/lib/VideoInputTest.ts
+++ b/lib/VideoInputTest.ts
@@ -279,7 +279,7 @@ export class VideoInputTest extends EventEmitter {
       ) {
         this._onError(new DiagnosticError(
           error,
-          'An `Error` has occurred.',
+          'An error has occurred.',
         ));
       } else {
         this._onError(new DiagnosticError(

--- a/lib/VideoInputTest.ts
+++ b/lib/VideoInputTest.ts
@@ -274,6 +274,13 @@ export class VideoInputTest extends EventEmitter {
           error,
           'A `DOMError` has occurred.',
         ));
+      } else if (
+        typeof Error !== 'undefined' && error instanceof Error
+      ) {
+        this._onError(new DiagnosticError(
+          error,
+          'An `Error` has occurred.',
+        ));
       } else {
         this._onError(new DiagnosticError(
           undefined,

--- a/tests/unit/AudioInputTest.ts
+++ b/tests/unit/AudioInputTest.ts
@@ -307,7 +307,9 @@ describe('testAudioInputDevice', function() {
     ], [
       'DOMError', new (global as any).DOMError(),
     ], [
-      'unknown error', new Error(),
+      'Error', new Error(),
+    ], [
+      'unknown error', {},
     ] ] as const).forEach(([title, error]) => {
       it(`of type ${title}`, async function() {
         const options = createTestOptions({

--- a/tests/unit/AudioOutputTest.ts
+++ b/tests/unit/AudioOutputTest.ts
@@ -241,7 +241,8 @@ describe('testAudioOutputDevice', function() {
     [new DiagnosticError(), 'DiagnosticError'],
     [new (global as any).DOMError(), 'DOMError'],
     [new (global as any).DOMException(), 'DOMException'],
-    [new Error(), 'an unknown error'],
+    [new Error(), 'Error'],
+    [{}, 'an unknown error'],
   ] as const).forEach(([error, name]) => {
     describe(`should handle ${name}`, function() {
       let report: AudioOutputTest.Report | undefined;

--- a/tests/unit/VideoInputTest.ts
+++ b/tests/unit/VideoInputTest.ts
@@ -265,7 +265,9 @@ describe('testVideoInputDevice', function() {
     ], [
       'DOMError', new (global as any).DOMError(),
     ], [
-      'unknown error', new Error(),
+      'Error', new Error(),
+    ], [
+      'unknown error', {},
     ] ] as const).forEach(([title, error]) => {
       it(`of type ${title}`, async function() {
         const options = createTestOptions({


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [CLIENT-8061](https://issues.corp.twilio.com/browse/CLIENT-8061)

### Description

This PR introduces error handling for FF specific `gUM` errors.

## Burndown

### Before review
* [x] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [x] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
