### PR TITLE
VIDEO-11571 Change blob type to mp4 instead of wav

### DIFF
--- a/lib/recorder/audio.ts
+++ b/lib/recorder/audio.ts
@@ -76,7 +76,10 @@ export class AudioRecorder {
    */
   private _generateObjectUrl(): void {
     // Use wav for faster and simple encoding
-    const blob = new Blob(this._audioData, { type: 'audio/wav' });
+    // Due to an iOS 16 MediaStream Recording issue found in iOS 16,
+    // We need to generate mp4 to work around this.
+    // https://bugs.webkit.org/show_bug.cgi?id=249250
+    const blob = new Blob(this._audioData, { type: 'audio/mp4' });
     this._url = URL.createObjectURL(blob);
     this._audioData = [];
   }

--- a/lib/recorder/audio.ts
+++ b/lib/recorder/audio.ts
@@ -73,13 +73,12 @@ export class AudioRecorder {
 
   /**
    * Generates the object url that can be used for audio playback from raw audio data
-   */
-  private _generateObjectUrl(): void {
-    // Use wav for faster and simple encoding
-    // Due to an iOS 16 MediaStream Recording issue found in iOS 16,
-    // We need to generate mp4 to work around this.
-    // https://bugs.webkit.org/show_bug.cgi?id=249250
-    const blob = new Blob(this._audioData, { type: 'audio/mp4' });
+  */
+ private _generateObjectUrl(): void {
+    // Select default browser mime type if it exists.
+    // Otherwise, use wav for faster and simple encoding.
+    const type: string = this._mediaRecorder ? this._mediaRecorder.mimeType : 'audio/wav';
+    const blob = new Blob(this._audioData, { type });
     this._url = URL.createObjectURL(blob);
     this._audioData = [];
   }

--- a/lib/recorder/audio.ts
+++ b/lib/recorder/audio.ts
@@ -74,10 +74,10 @@ export class AudioRecorder {
   /**
    * Generates the object url that can be used for audio playback from raw audio data
   */
- private _generateObjectUrl(): void {
+  private _generateObjectUrl(): void {
     // Select default browser mime type if it exists.
     // Otherwise, use wav for faster and simple encoding.
-    const type: string = this._mediaRecorder ? this._mediaRecorder.mimeType : 'audio/wav';
+    const type: string = this._mediaRecorder && this._mediaRecorder.mimeType ? this._mediaRecorder.mimeType : 'audio/wav';
     const blob = new Blob(this._audioData, { type });
     this._url = URL.createObjectURL(blob);
     this._audioData = [];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -70,6 +70,7 @@ export namespace MediaStreamRecorder {
     data: AudioData;
   }
   export interface MediaRecorder {
+    mimeType?: string;
     ondataavailable: Function;
     onstop: Function;
     start: Function;

--- a/tests/unit/recorder/audio.ts
+++ b/tests/unit/recorder/audio.ts
@@ -92,4 +92,16 @@ describe('AudioRecorder', () => {
     audioRecorder.stop();
     assert.equal(audioRecorder.url, 'foo,bar,baz');
   });
+
+  [ 'audio/mp4', 'audio/webm', undefined ].forEach(mimeType => {
+    MediaRecorderFactory.mimeType = mimeType;
+    it('should use mime type chosen by browser', () => {
+      audioRecorder.stop();
+      if(mimeType) {
+        assert.equal(mediaRecorderInstance.mimeType, mimeType);
+      } else {
+        assert.equal(mediaRecorderInstance.mimeType, 'audio/wav');
+      }
+    });
+  });
 });


### PR DESCRIPTION
Due to an issue reported [here](https://bugs.webkit.org/show_bug.cgi?id=249250) as well as the below escalation, Apple has suggested we try using `audio/mp4` blob type to work around the current bug.

This bug can be reproduced within our own application as well in the [video diagnostics app](https://video-diagnostics.twilio.com/)

**The repro steps are as follows:**
1. **On an iOS 16 device** open the [video diagnostics app](https://video-diagnostics.twilio.com/)
2. Grant permissions to the app
3. Continue to the Test your audio page
4. Ensure microphone and speaker has been selected
5. Click **Record**
6. Allow for the test to finish
7. Click **Play back**

Expected:
Recorded audio to play back

Actual:
An error is returned that there is no audio device selected

Note: 
On my current laptop, I can't install the packages so I cannot manually test this. I've been testing locally by building manually (running `tsc`) as well as running npm pack to get the bundle.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-11571](https://issues.corp.twilio.com/browse/VIDEO-11571)

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [ ] Verified locally with `npm test`
* [ ] Manually sanity tested running locally
* [ ] Included screenshot as PR comment (if needed)
* [ ] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
